### PR TITLE
Remove 'desktop-icons-neo'

### DIFF
--- a/any/mlc.toml
+++ b/any/mlc.toml
@@ -17,7 +17,6 @@ repos = [
 	"age:gsconnect",
 	"aur:timeshift-autosnap",
 	"age:caffeine",
-	"age:desktop-icons-neo",
 	"pkg:crystal-dev",
 	"pkg:crystal-keyring",
 	"pkg:crystal-mirrorlist",


### PR DESCRIPTION
Hi,

Since `gnome-shell-extension-desktop-icons-neo` has been dropped from `onyx` we might just as well remove it from our repo so people can directly use the AUR package instead if they want to.

